### PR TITLE
bump to copy-browser-modules v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "copy-browser-modules": "^3.0.0"
+    "copy-browser-modules": "^4.0.0"
   }
 }


### PR DESCRIPTION
To take advantage of this change:
https://github.com/aredridel/copy-browser-modules/pull/6
